### PR TITLE
fix: refresh session token when the error code is in an enhanced message

### DIFF
--- a/src/Betfair.Tests/Core/Client/HttpTokenInjectorTests.cs
+++ b/src/Betfair.Tests/Core/Client/HttpTokenInjectorTests.cs
@@ -62,6 +62,16 @@ public class HttpTokenInjectorTests : IDisposable
         _tokenProvider.TokensUsed.Should().Be(2);
     }
 
+    [Fact]
+    public async Task TokenIsRefreshedIfSessionIsInvalidWhenErrorCodeIsInEnhancedMessage()
+    {
+        _httpClient.ThrowsError = "Invalid session information. (Error code: INVALID_SESSION_INFORMATION)";
+
+        await _tokenInjector.PostAsync<dynamic>(_uri, _content, TestContext.Current.CancellationToken);
+
+        _tokenProvider.TokensUsed.Should().Be(2);
+    }
+
     [Theory]
     [InlineData("FirstToken", "SecondToken")]
     [InlineData("OtherToken", "NewToken")]

--- a/src/Betfair/Core/Client/HttpTokenInjector.cs
+++ b/src/Betfair/Core/Client/HttpTokenInjector.cs
@@ -36,7 +36,7 @@ internal class HttpTokenInjector : IHttpClient
     }
 
     private static bool SessionIsValid(HttpRequestException e) =>
-        e.Message != "INVALID_SESSION_INFORMATION";
+        !e.Message.Contains("INVALID_SESSION_INFORMATION", StringComparison.Ordinal);
 
     private async Task<T> PostFunc<T>(Func<Task<T>> func, HttpContent content, CancellationToken ct)
         where T : class


### PR DESCRIPTION
Addresses #19 (approach 1 of 2).
Replaces the exact-equality check in `SessionIsValid` with an ordinal substring match, so the decorated error message still triggers a refresh. Smallest change, keeps the existing message-based approach. All 1447 tests pass (net10.0).

Alternative to #21 